### PR TITLE
adb: Look for bu in /sbin when in recovery mode

### DIFF
--- a/adb/adb.h
+++ b/adb/adb.h
@@ -231,6 +231,8 @@ int is_adb_interface(int vid, int pid, int usb_class, int usb_subclass, int usb_
 
 ConnectionState connection_state(atransport *t);
 
+extern int recovery_mode;
+
 extern const char* adb_device_banner;
 
 #if !ADB_HOST

--- a/adb/daemon/main.cpp
+++ b/adb/daemon/main.cpp
@@ -224,6 +224,10 @@ int adbd_main(int server_port) {
     return 0;
 }
 
+#if !ADB_HOST
+int recovery_mode = 0;
+#endif
+
 int main(int argc, char** argv) {
     while (true) {
         static struct option opts[] = {
@@ -255,6 +259,8 @@ int main(int argc, char** argv) {
             return 1;
         }
     }
+
+    recovery_mode = (strcmp(adb_device_banner, "recovery") == 0);
 
     close_stdin();
 

--- a/adb/services.cpp
+++ b/adb/services.cpp
@@ -287,6 +287,13 @@ static int create_service_thread(void (*func)(int, void *), void *cookie)
     return s[0];
 }
 
+#if !ADB_HOST
+static const char* bu_path()
+{
+    return (recovery_mode ? "/sbin/bu" : "/system/bin/bu");
+}
+#endif
+
 int service_to_fd(const char* name, const atransport* transport) {
     int ret = -1;
 
@@ -344,12 +351,13 @@ int service_to_fd(const char* name, const atransport* transport) {
     } else if(!strncmp(name, "unroot:", 7)) {
         ret = create_service_thread(restart_unroot_service, NULL);
     } else if(!strncmp(name, "backup:", 7)) {
-        ret = StartSubprocess(android::base::StringPrintf("/system/bin/bu backup %s",
+        ret = StartSubprocess(android::base::StringPrintf("%s backup %s", bu_path(),
                                                           (name + 7)).c_str(),
                               nullptr, SubprocessType::kRaw, SubprocessProtocol::kNone);
     } else if(!strncmp(name, "restore:", 8)) {
-        ret = StartSubprocess("/system/bin/bu restore", nullptr, SubprocessType::kRaw,
-                              SubprocessProtocol::kNone);
+        ret = StartSubprocess(
+            android::base::StringPrintf("%s restore", bu_path()).c_str(),
+            nullptr, SubprocessType::kRaw, SubprocessProtocol::kNone);
     } else if(!strncmp(name, "tcpip:", 6)) {
         int port;
         if (sscanf(name + 6, "%d", &port) != 1) {


### PR DESCRIPTION
 * Restore global variable recovery_mode.  This is set based on the
   commandline parameter --banner.

 * Use recovery_mode to select path to 'bu' binary for both backup and
   restore services.

Change-Id: Ie4c945d00601514d7f16357bae10ff7f232633e1

adb: Fix recovery_mode

 * adb_trace_init() exits early, put the banner check in main().

Change-Id: I83d0b83076a3d97fdec41b2cf02ee45805a53c6f