### PR TITLE
debuggerd: add Lineage version to tombstones

### DIFF
--- a/debuggerd/libdebuggerd/tombstone.cpp
+++ b/debuggerd/libdebuggerd/tombstone.cpp
@@ -210,10 +210,13 @@ static const char* get_sigcode(int signo, int code) {
 static void dump_header_info(log_t* log) {
   char fingerprint[PROPERTY_VALUE_MAX];
   char revision[PROPERTY_VALUE_MAX];
+  char lineage_version[PROPERTY_VALUE_MAX];
 
+  property_get("ro.lineage.version", lineage_version, "unknown");
   property_get("ro.build.fingerprint", fingerprint, "unknown");
   property_get("ro.revision", revision, "unknown");
 
+  _LOG(log, logtype::HEADER, "LineageOS Version: '%s'\n", lineage_version);
   _LOG(log, logtype::HEADER, "Build fingerprint: '%s'\n", fingerprint);
   _LOG(log, logtype::HEADER, "Revision: '%s'\n", revision);
   _LOG(log, logtype::HEADER, "ABI: '%s'\n", ABI_STRING);


### PR DESCRIPTION
Change-Id: I7822a2e133a2f326ad2d8da8f79b0064344d59bf

debuggerd: Rebrand tombstone header to LineageOS

[harryyoud]: Use new props for 15.1

Change-Id: Idd08c2eb7e395b464b1510742bf52833f465db08