### PR TITLE
make_f2fs: specify sector size for target image size

### DIFF
--- a/fs_mgr/fs_mgr_format.cpp
+++ b/fs_mgr/fs_mgr_format.cpp
@@ -114,10 +114,19 @@ static int format_f2fs(char *fs_blkdev, uint64_t dev_sz, bool crypt_footer)
     }
 
     std::string size_str = std::to_string(dev_sz / 4096);
+    // clang-format off
     const char* const args[] = {
-        "/system/bin/make_f2fs", "-d1", "-f",
-        "-O", "encrypt", "-O", "quota",
-        fs_blkdev, size_str.c_str(), nullptr};
+        "/system/bin/make_f2fs",
+        "-d1",
+        "-f",
+        "-O", "encrypt",
+        "-O", "quota",
+        "-w", "4096",
+        fs_blkdev,
+        size_str.c_str(),
+        nullptr
+    };
+    // clang-format on
 
     return android_fork_execvp_ext(arraysize(args), const_cast<char**>(args), NULL, true,
                                    LOG_KLOG, true, nullptr, nullptr, 0);


### PR DESCRIPTION
The total sectors that we want to format is used in different meanings from
various users. This notifies its size based on 4096 bytes explicitly.

Bug: 76407663
Change-Id: I4e00f2e2289c1381f0238d2a4acb606a0ab551a9
Merged-In: I4e00f2e2289c1381f0238d2a4acb606a0ab551a9
Reported-by: katao@xiaomi.com
Signed-off-by: Jaegeuk Kim <jaegeuk@google.com>