### PR TITLE
Revert "Don't enable ADB by default when ro.adb.secure is 1"

### DIFF
--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -659,11 +659,11 @@ static void load_persistent_properties() {
 // So we need to apply the same rule of build/make/tools/post_process_props.py
 // on runtime.
 static void update_sys_usb_config() {
-    bool is_secure = android::base::GetBoolProperty("ro.adb.secure", true);
+    bool is_debuggable = android::base::GetBoolProperty("ro.debuggable", false);
     std::string config = android::base::GetProperty("persist.sys.usb.config", "");
     if (config.empty()) {
-        property_set("persist.sys.usb.config", !is_secure ? "adb" : "none");
-    } else if (!is_secure && config.find("adb") == std::string::npos &&
+        property_set("persist.sys.usb.config", is_debuggable ? "adb" : "none");
+    } else if (is_debuggable && config.find("adb") == std::string::npos &&
                config.length() + 4 < PROP_VALUE_MAX) {
         config.append(",adb");
         property_set("persist.sys.usb.config", config);


### PR DESCRIPTION
 * This caused sys.usb.config set to none after boot, MTP and adb
   are both unusable.

This reverts commit 47c2f914bd3203431ed386e2b144bdcd9ac1cd28.

Change-Id: Icd16f2837f2479bfba164c88e32295ec684b15b0