### PR TITLE
camera: Add L-compatible camera feature enums

### DIFF
--- a/libsystem/include/system/camera.h
+++ b/libsystem/include/system/camera.h
@@ -200,6 +200,7 @@ enum {
      * IMPLEMENTATION_DEFINED, then HALv3 devices will use gralloc usage flags
      * of SW_READ_OFTEN.
      */
+#ifndef CAMERA_VENDOR_L_COMPAT
     CAMERA_CMD_SET_VIDEO_FORMAT = 11,
 
     CAMERA_CMD_VENDOR_START = 20,
@@ -219,6 +220,20 @@ enum {
     CAMERA_CMD_METADATA_ON = CAMERA_CMD_VENDOR_START + 6,
     CAMERA_CMD_METADATA_OFF = CAMERA_CMD_VENDOR_START + 7,
     CAMERA_CMD_VENDOR_END = 200,
+#else
+    /**
+     * Values used by older HALs, provided as an option for compatibility
+     */
+    CAMERA_CMD_HISTOGRAM_ON = 11,
+    CAMERA_CMD_HISTOGRAM_OFF = 12,
+    CAMERA_CMD_HISTOGRAM_SEND_DATA = 13,
+    CAMERA_CMD_LONGSHOT_ON = 14,
+    CAMERA_CMD_LONGSHOT_OFF = 15,
+    CAMERA_CMD_STOP_LONGSHOT = 16,
+    CAMERA_CMD_METADATA_ON = 100,
+    CAMERA_CMD_METADATA_OFF = 101,
+    CAMERA_CMD_SET_VIDEO_FORMAT = 102,
+#endif
 };
 
 /** camera fatal errors */


### PR DESCRIPTION
 * These QC-specific features have been renumbered in M, so add
   a compilation flag to permit using the old versions in case we
   can't rebuild the driver.

Change-Id: I3f5a545fde8b27684b1b8ea490c09bb66e3b4cd9